### PR TITLE
[FIX] Replace old logo and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Ably](https://s3.amazonaws.com/files.ably.io/logo-with-type.png)](https://www.ably.io)
+[![Ably](https://static.ably.dev/logo-h-black.svg?ably-tutorials)](https://www.ably.com)
 
 ---
 
@@ -6,8 +6,8 @@
 
 _[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
 
-This repository contains the working code for many of the [Ably tutorials](https://www.ably.io/tutorials).
+This repository contains the working code for many of the [Ably tutorials](https://www.ably.com/tutorials).
 
-See [https://www.ably.io/tutorials](https://www.ably.io/tutorials) for a complete list of Ably tutorials. The source code for each tutorial exists as a branch in this repo, see [the complete list of tutorial branches in this repository](https://github.com/ably/tutorials/branches/all).
+See [https://www.ably.com/tutorials](https://www.ably.com/tutorials) for a complete list of Ably tutorials. The source code for each tutorial exists as a branch in this repo, see [the complete list of tutorial branches in this repository](https://github.com/ably/tutorials/branches/all).
 
-To find out more Ably and our realtime data delivery platform, visit [https://www.ably.io](https://www.ably.io)
+To find out more Ably and our realtime data delivery platform, visit [https://www.ably.com](https://www.ably.com)


### PR DESCRIPTION
- Replace Ably logo with new branding and 
- Update the README link to replace .io in with .com URL

This is root readme ONLY. There are no changes to content.

![2022-05-17-164130_468x125_scrot](https://user-images.githubusercontent.com/944315/168852411-d0133b05-a6ca-46a9-a18f-037280b2cada.png)

https://ably.atlassian.net/browse/EDU-909